### PR TITLE
feat: カスタム Dockerfile への切り替えと console.error の削除

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,19 @@
+# Node.jsのDockerイメージを取得する：
+FROM node:24-alpine
+
+# npmの更新
+RUN npm install -g npm@11.11.0
+
+# 依存ツールのインストール（キャッシュなし）
+RUN apk add --no-cache \
+    bash \
+    git \
+    github-cli \
+    openssh-client
+
+
+# SHELL環境の設定
+ENV SHELL=/bin/sh
+
+# Claude Code: 自動メモリー作成の抑制
+ENV CLAUDE_CODE_DISABLE_AUTO_MEMORY=1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,87 +1,21 @@
-// Obsidian プラグイン開発用の Dev Container 設定ファイル
-// Dev Container とは、Docker コンテナの中に開発環境を丸ごと構築する仕組みです。
-// これにより、誰でも同じ環境で開発を始められます。
-// 参考: https://github.com/obsidianmd/obsidian-sample-plugin
 {
 	// このコンテナの表示名（VS Code の左下などに表示されます）
 	"name": "Obsidian Ananke",
-
-	// ベースとなる Docker イメージ
-	// Microsoft 公式の TypeScript + Node.js 24 が入った開発用イメージを使います
-	"image": "mcr.microsoft.com/devcontainers/typescript-node:24",
-
-	// コンテナに追加でインストールする機能（ツール）
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
 	"features": {
 		// Claude Code — AI によるコーディング支援ツール
-		"ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
-		// GitHub CLI（gh コマンド）— リリース作業や PR 操作に使います
-		"ghcr.io/devcontainers/features/github-cli:1": {}
+		"ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {}
 	},
-
-	// VS Code 固有の設定
+	"postCreateCommand": "npm install --save-dev",
+	"remoteUser": "node",
 	"customizations": {
 		"vscode": {
-			// エディタの設定
-			"settings": {
-				// ファイル保存時に自動フォーマットする
-				"editor.formatOnSave": true,
-				// フォーマッターとして ESLint を使う
-				"editor.defaultFormatter": "dbaeumer.vscode-eslint",
-				// 保存時に ESLint の自動修正を実行する
-				"editor.codeActionsOnSave": {
-					"source.fixAll.eslint": "explicit"
-				},
-				// プロジェクト内の TypeScript を使う（グローバル版ではなく）
-				"typescript.tsdk": "node_modules/typescript/lib",
-				// 「ワークスペースの TypeScript を使いますか？」と聞いてくれる
-				"typescript.enablePromptUseWorkspaceTsdk": true,
-				"claudeCode.allowDangerouslySkipPermissions": true,
-				"claudeCode.usePythonEnvironment": false
-			},
-			// 自動でインストールされる VS Code 拡張機能
 			"extensions": [
-				// ESLint — コードの問題を検出・修正する
-				"dbaeumer.vscode-eslint",
-				// Prettier — コードフォーマッター
-				"esbenp.prettier-vscode",
-				// EditorConfig — インデントや改行コードを統一する
-				"EditorConfig.EditorConfig",
-				// Claude Code統合（AI支援開発）
-				"Anthropic.claude-code"
+				"Anthropic.claude-code",
+				"github.vscode-github-actions"
 			]
 		}
-	},
-
-	// コンテナ作成後に自動で実行されるコマンド
-	// npm install で必要なパッケージをインストールします
-	"postCreateCommand": "npm install --save-dev",
-
-	// コンテナ外からアクセスしたいポート（ホットリロード用など）
-	// 現在は特に設定なし
-	"forwardPorts": [],
-
-	// ボリュームマウントの設定
-	// npm のキャッシュを永続化して、コンテナを再作成しても
-	// パッケージのダウンロードが速くなるようにします
-	"mounts": [
-		"source=obsidian-plugin-dev-npm-cache,target=/home/node/.npm,type=volume"
-	],
-
-	// コンテナ内で使うユーザー
-	// root ではなく「node」ユーザーで実行します（セキュリティのため）
-	"remoteUser": "node",
-
-	// Linuxケイパビリティの制限
-	// Linuxケイパビリティ: rootの権限を細かく分割した特殊な権限
-	// 空の配列 = 追加の特権を一切付与しない
-	// これにより、ネットワーク設定変更やシステム時刻変更などの
-	// 危険な操作ができないようになります。
-	"capAdd": [],
-
-	// 権限昇格の禁止
-	// no-new-privileges: プロセスが自分より高い権限を取得することを禁止
-	// 例: setuidプログラム（通常ユーザーがroot権限で実行できるプログラム）を
-	// 実行しても、root権限が得られないようにします。
-	// これにより、コンテナ内での権限昇格攻撃を防ぎます。
-	"securityOpt": ["no-new-privileges=true"]
+	}
 }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@
 # 対象:
 #   1. npm パッケージ（devDependencies と dependencies）
 #   2. GitHub Actions ワークフロー
+#   3. Docker イメージ（.devcontainer/Dockerfile）
 #
 # 更新頻度:
 #   - 毎週月曜日に自動チェック
@@ -34,48 +35,17 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
-      time: "09:00"
       timezone: "Asia/Tokyo"
 
     # プルリクエストのアサイン先
     assignees:
       - "murnana"
 
-    # 同時に開くプルリクエストの最大数
-    open-pull-requests-limit: 5
-
-    # プルリクエストに付けるラベル
-    labels:
-      - "dependencies"
-      - "npm"
-
-    # コミットメッセージのプレフィックス
-    commit-message:
-      prefix: "chore(deps)"
-      include: "scope"
-
-    # パッケージグループ化
-    # 複数のパッケージを1つのPRにまとめることで、レビュー負荷を軽減
-    groups:
-      # 開発ツールをまとめて更新
-      development-dependencies:
-        patterns:
-          - "@types/*"
-          - "@typescript-eslint/*"
-          - "eslint*"
-          - "typescript"
-        update-types:
-          - "minor"
-          - "patch"
-
-      # ビルドツールをまとめて更新
-      build-tools:
-        patterns:
-          - "esbuild"
-          - "lightningcss"
-        update-types:
-          - "minor"
-          - "patch"
+    # クールダウン期間
+    # パッケージ公開から 7 日経過するまで更新 PR を作成しない
+    # (.npmrc の min-release-age=7 と整合)
+    cooldown:
+      default-days: 7
 
   # ---------------------------------------------------------------------------
   # GitHub Actions の自動更新
@@ -96,22 +66,35 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
-      time: "09:00"
       timezone: "Asia/Tokyo"
 
     # プルリクエストのアサイン先
     assignees:
       - "murnana"
 
-    # 同時に開くプルリクエストの最大数
-    open-pull-requests-limit: 5
+    # クールダウン期間
+    # アクション公開から 7 日経過するまで更新 PR を作成しない
+    cooldown:
+      default-days: 7
 
-    # プルリクエストに付けるラベル
-    labels:
-      - "dependencies"
-      - "github-actions"
+  # ---------------------------------------------------------------------------
+  # Docker イメージの自動更新
+  # ---------------------------------------------------------------------------
+  # .devcontainer/Dockerfile のベースイメージ (FROM) を監視し、
+  # 更新可能なバージョンがある場合はプルリクエストを作成します。
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "docker"
+    directory: "/.devcontainer"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      timezone: "Asia/Tokyo"
 
-    # コミットメッセージのプレフィックス
-    commit-message:
-      prefix: "chore(ci)"
-      include: "scope"
+    # プルリクエストのアサイン先
+    assignees:
+      - "murnana"
+
+    # クールダウン期間
+    # イメージ公開から 7 日経過するまで更新 PR を作成しない
+    cooldown:
+      default-days: 7

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 tag-version-prefix=""
 engine-strict=true
+min-release-age=7

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"builtin-modules": "5.0.0",
 				"esbuild": "0.28.0",
 				"lightningcss": "^1.32.0",
-				"obsidian": "*",
+				"obsidian": "latest",
 				"ts-node": "^10.9.2",
 				"tslib": "2.8.1",
 				"typescript": "5.9.3"

--- a/src/Parsers/DailyPlanParser.ts
+++ b/src/Parsers/DailyPlanParser.ts
@@ -65,7 +65,6 @@ export class DailyPlanParser {
 					tasks.push(task);
 					order++;
 				} catch (error) {
-					console.error(`Failed to parse task at line ${i + 1}: ${line}`, error);
 					throw new Error(`Invalid task row at line ${i + 1}: ${error instanceof Error ? error.message : String(error)}`);
 				}
 			}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+	"ignoreDeprecations": "6.0",
     "baseUrl": "./src",
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-	"ignoreDeprecations": "6.0",
+	"ignoreDeprecations": "5.0",
     "baseUrl": "./src",
     "inlineSourceMap": true,
     "inlineSources": true,


### PR DESCRIPTION
## 概要

- `.devcontainer` をカスタム Dockerfile ベースに切り替え（`node:24-alpine`）
- Dev Container 設定をシンプル化（不要なコメント・設定を削除）
- `dependabot.yml` に Docker イメージ監視を追加し、クールダウン期間を設定
- `.npmrc` に `min-release-age=7` を追加
- `DailyPlanParser` でエラー再スロー前の冗長な `console.error` を削除

## テスト計画

- [ ] `npm run test` が全 22 件パスすること
- [ ] テスト実行時に余分なログ出力が出ないこと
- [ ] Dev Container がビルド・起動できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)