### PR TITLE
chore(deps): Dependabot で @typescript-eslint/* をグループ更新にする

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,15 @@ updates:
     assignees:
       - "murnana"
 
+    # 依存関係のグループ化
+    # peer dependency でバージョンを揃える必要があるパッケージは
+    # 1つのグループにまとめ、同一 PR・同一バージョンで更新する。
+    # (@typescript-eslint/eslint-plugin は parser に同一バージョンを要求するため)
+    groups:
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"
+
     # クールダウン期間
     # パッケージ公開から 7 日経過するまで更新 PR を作成しない
     # (.npmrc の min-release-age=7 と整合)


### PR DESCRIPTION
## 背景

`@typescript-eslint/eslint-plugin` は `@typescript-eslint/parser` に対して同一バージョンの peer dependency を要求します。しかし現在の Dependabot 設定には `groups` が無く、両者が別々の PR で更新されていました。その結果、片方だけがバージョンアップした状態で `npm install` すると ERESOLVE エラーで失敗します（直近、devcontainer の postCreateCommand で実際に発生）。

## 変更内容

`.github/dependabot.yml` の npm エントリに `groups` を追加し、`@typescript-eslint/*` を常に同一 PR・同一バージョンで更新するようにしました。

```yaml
groups:
  typescript-eslint:
    patterns:
      - "@typescript-eslint/*"
```

## 検証

- ruby で YAML 構文と `groups` 構造が妥当であることを確認済み
- 実効性の最終確認は次回の Dependabot 実行時（土曜）に `@typescript-eslint/*` が単一 PR でまとまることで判断します

🤖 Generated with [Claude Code](https://claude.com/claude-code)